### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/shailesh0220/9d069393-9a05-4e92-90bd-43c783a14091/cae57a87-89eb-42d8-b38e-a7b0250242d9/_apis/work/boardbadge/7701c0ab-1914-472a-99bd-950c5d1c1f72)](https://dev.azure.com/shailesh0220/9d069393-9a05-4e92-90bd-43c783a14091/_boards/board/t/cae57a87-89eb-42d8-b38e-a7b0250242d9/Microsoft.RequirementCategory)
 # test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/shailesh0220/9d069393-9a05-4e92-90bd-43c783a14091/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.